### PR TITLE
Add command notifications, unlock command, and improve logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,46 +264,46 @@ jobs:
           generate_release_notes: true
           files: '*/${{ vars.PACKAGE_NAME }}-*.*'
 
-  cargo-publish:
-    name: Publish to crates.io
-    runs-on: ubuntu-latest
-    needs: [release]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  # cargo-publish:
+  #   name: Publish to crates.io
+  #   runs-on: ubuntu-latest
+  #   needs: [release]
+  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
-    environment:
-      name: crates.io
+  #   environment:
+  #     name: crates.io
 
-    steps:
-      - uses: actions/checkout@v5
+  #   steps:
+  #     - uses: actions/checkout@v5
 
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y install pkg-config
+  #     - name: Install dependencies
+  #       run: sudo apt-get update && sudo apt-get -y install pkg-config
 
-      - name: Install Rust toolchain
-        run: rustup update stable
+  #     - name: Install Rust toolchain
+  #       run: rustup update stable
 
-      - name: Verify version matches tag
-        run: |
-          TAG_VERSION=${GITHUB_REF#refs/tags/v}
-          CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+  #     - name: Verify version matches tag
+  #       run: |
+  #         TAG_VERSION=${GITHUB_REF#refs/tags/v}
+  #         CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 
-          echo "Tag version: $TAG_VERSION"
-          echo "Cargo.toml version: $CARGO_VERSION"
+  #         echo "Tag version: $TAG_VERSION"
+  #         echo "Cargo.toml version: $CARGO_VERSION"
 
-          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
-            echo "ERROR: Version mismatch: tag $TAG_VERSION != Cargo.toml $CARGO_VERSION"
-            exit 1
-          fi
+  #         if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+  #           echo "ERROR: Version mismatch: tag $TAG_VERSION != Cargo.toml $CARGO_VERSION"
+  #           exit 1
+  #         fi
 
-          echo "SUCCESS: Version match confirmed"
+  #         echo "SUCCESS: Version match confirmed"
 
-      - name: Dry run publish
-        run: cargo publish --dry-run --locked
+  #     - name: Dry run publish
+  #       run: cargo publish --dry-run --locked
 
-      - name: Publish crate
-        run: cargo publish --locked
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  #     - name: Publish crate
+  #       run: cargo publish --locked
+  #       env:
+  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   copr-trigger:
     name: Trigger COPR Build
@@ -312,11 +312,59 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
+      - name: Extract tag version
+        id: version
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
       - name: Trigger COPR webhook
         run: |
-          curl -X POST \
-            -H "Content-Type: application/json" \
-            -d '{"ref": "${{ github.ref }}", "repository": {"clone_url": "${{ github.event.repository.clone_url }}"}}' \
-            "https://copr.fedorainfracloud.org/webhooks/github/${{ secrets.COPR_PROJECT_ID }}/${{ secrets.COPR_WEBHOOK_KEY }}/${{ vars.PACKAGE_NAME }}/"
+          # Get the tag version
+          TAG_VERSION="${{ steps.version.outputs.tag }}"
 
-          echo "SUCCESS: COPR build triggered successfully"
+          # Create proper GitHub webhook payload format
+          PAYLOAD=$(cat <<EOF
+          {
+            "ref": "${{ github.ref }}",
+            "after": "${{ github.sha }}",
+            "repository": {
+              "clone_url": "${{ github.event.repository.clone_url }}",
+              "full_name": "${{ github.repository }}",
+              "html_url": "${{ github.event.repository.html_url }}"
+            },
+            "head_commit": {
+              "id": "${{ github.sha }}",
+              "message": "Release $TAG_VERSION"
+            },
+            "pusher": {
+              "name": "${{ github.actor }}"
+            }
+          }
+          EOF
+          )
+
+          # Send webhook with proper error handling
+          echo "Sending COPR webhook for $TAG_VERSION..."
+          echo "URL: https://copr.fedorainfracloud.org/webhooks/github/${{ secrets.COPR_PROJECT_ID }}/${{ secrets.COPR_WEBHOOK_KEY }}/${{ vars.PACKAGE_NAME }}/"
+
+          RESPONSE=$(curl -s -w "HTTPSTATUS:%{http_code}" -X POST \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: GitHub-Hookshot" \
+            -H "X-GitHub-Event: push" \
+            -d "$PAYLOAD" \
+            "https://copr.fedorainfracloud.org/webhooks/github/${{ secrets.COPR_PROJECT_ID }}/${{ secrets.COPR_WEBHOOK_KEY }}/${{ vars.PACKAGE_NAME }}/")
+
+          # Extract HTTP status and body
+          HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+          HTTP_BODY=$(echo $RESPONSE | sed -E 's/HTTPSTATUS\:[0-9]{3}$//')
+
+          echo "HTTP Status: $HTTP_STATUS"
+          echo "Response Body: $HTTP_BODY"
+
+          # Check for successful response
+          if [ "$HTTP_STATUS" -eq 200 ] || [ "$HTTP_STATUS" -eq 201 ] || [ "$HTTP_STATUS" -eq 202 ]; then
+            echo "SUCCESS: COPR build triggered successfully"
+          else
+            echo "ERROR: COPR webhook failed with status $HTTP_STATUS"
+            echo "Response: $HTTP_BODY"
+            exit 1
+          fi

--- a/config.example.toml
+++ b/config.example.toml
@@ -6,14 +6,14 @@
 # Verbosity level from 0-3. 0 means minimal output, 3 means very verbose.
 verbosity_level = 1
 
-# Directory for backup statistics logs (used for Json and Logfile formats)
+# Directory for backup statistics logs (used for json and logfile formats)
 stats_dir = "/var/log/restic-scheduler"
 
 # Statistics logging format - choose one:
-# "Json" - Log statistics to JSON Lines files (.jsonl) in stats_dir
-# "Stdout" - Log statistics as structured log events to stdout (for log aggregation systems)
-# "Logfile" - Log statistics as structured log events to profile-named log files in stats_dir
-stats_format = "Json"
+# "json" - Log statistics to JSON Lines files (.jsonl) in stats_dir (also always logs to stdout)
+# "logfile" - Log statistics as structured log events to profile-named log files in stats_dir (also always logs to stdout)
+# Note: All logging formats always output to stdout. json and logfile formats additionally write to files if stats_dir is configured.
+stats_format = "json"
 
 # Default profile using Backblaze B2
 [profiles.default]
@@ -112,6 +112,14 @@ from = "your-email@gmail.com"
 to = ["admin@example.com", "backup-admin@example.com"]
 use_tls = true
 
+# Command notifications - execute custom commands on backup events
+[profiles.default.notifications.command]
+notify_on_success = false  # Set to true if you want success notifications
+notify_on_failure = true   # Execute command on backup failures
+command = "/usr/local/bin/notify-backup"  # Path to your notification script
+args = ["--profile", "default", "--type", "backup"]  # Arguments to pass
+timeout = 30  # Command timeout in seconds
+
 # S3-compatible backup profile
 [profiles.s3-backup]
 repository = "s3:my-backup-bucket/restic"
@@ -175,3 +183,11 @@ method = "POST"
 timeout = 30
 # Additional headers (Content-Type: application/json is set automatically)
 headers = { "Authorization" = "Bearer your-token" }
+
+# Command notifications for S3 profile
+[profiles.s3-backup.notifications.command]
+notify_on_success = true   # Notify on successful S3 backups
+notify_on_failure = true   # Notify on failed S3 backups
+command = "/usr/local/bin/s3-backup-notify"
+args = ["--webhook", "--discord"]
+timeout = 60

--- a/src/restic.rs
+++ b/src/restic.rs
@@ -96,8 +96,8 @@ impl ResticCommand {
             .context("Failed to execute restic unlock command")?;
 
         if !output.status.success() {
-            let error = String::from_utf8_lossy(&output.stderr);
-            warn!("Failed to unlock repository: {}", error);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Failed to unlock repository: {}", stderr);
         } else {
             debug!("Repository unlocked successfully");
         }

--- a/systemd/restic-backup@.service
+++ b/systemd/restic-backup@.service
@@ -9,7 +9,7 @@ User=restic-scheduler
 Group=restic-scheduler
 
 # Backup command with profile
-ExecStart=/usr/bin/restic-scheduler --profile %i backup --random-delay 300 --skip-if-running
+ExecStart=/usr/bin/restic-scheduler --profile %i backup
 
 # Resource limits
 Nice=10

--- a/systemd/restic-backup@.timer
+++ b/systemd/restic-backup@.timer
@@ -3,9 +3,8 @@ Description=Schedule Restic Backup (%i profile)
 Requires=restic-backup@%i.service
 
 [Timer]
-# Run daily at 02:00 with random delay up to 3 hours
+# Run daily at 02:00
 OnCalendar=*-*-* 02:00:00
-RandomizedDelaySec=3h
 Persistent=true
 
 [Install]

--- a/systemd/restic-check@.timer
+++ b/systemd/restic-check@.timer
@@ -3,9 +3,8 @@ Description=Schedule Restic Repository Check (%i profile)
 Requires=restic-check@%i.service
 
 [Timer]
-# Run weekly on Sunday at 03:00 with random delay up to 2 hours
+# Run weekly on Sunday at 03:00
 OnCalendar=Sun *-*-* 03:00:00
-RandomizedDelaySec=2h
 Persistent=true
 
 [Install]


### PR DESCRIPTION
- Add support for custom command notifications on backup/check events - Implement `unlock` command to remove stale repository locks for one or all profiles - Always log statistics to stdout; json/logfile formats also write to files if configured - Remove random delay and skip-if-running options from backup CLI and systemd units - Update documentation and example config for new features - Improve error handling and notification messages - Bump RPM spec version to 0.2.0 and enhance systemd unit management on uninstall